### PR TITLE
IN-476: Add support for PHP 5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM compucorp/civicrm-buildkit:latest
+ARG php_version=7.2
+FROM compucorp/civicrm-buildkit:1.0.0-php${php_version}
 
-COPY entrypoint.sh /entrypoint.sh
-COPY settings.php /settings.php
-COPY build-update-message.php /build-update-message.php
-COPY create-pull-request.php /create-pull-request.php
+ENV CIVICRM_ROOT sites/all/modules/civicrm
+
+COPY [ "entrypoint.sh", "*.php", "/" ]
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ containing a valid schema (anonymized or not) for the site in the workflow repo.
 [compucorp/mysql-anondb](https://github.com/compucorp/mysql-anondb-docker) for that.
 
 Since the action includes some logic based on the existence of tags and branches, it cannot be used in a shallow clone. 
-Make sure of adding `fetch-depth: 0` to your step reponsible for checking out the code.
+Make sure of adding `fetch-depth: 0` to your step responsible for checking out the code.
 
 ## Usage
 
@@ -48,9 +48,9 @@ jobs:
 
       - name: Security updates
         id: security-updates
-        uses: compucorp/drupal7-security-updates@v1.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker://compucorp/drupal7-security-updates-action:1.0.0-php7.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 The action will always consider the latest tag as the base for security updates. This is based on the assumption that 
@@ -60,6 +60,11 @@ instead.
 If there are security updates available, they will be pushed to a branch named `<tag or master>_security_updates`. A 
 Pull Request will also be created targetting `master`. Both the commit and the Pull Request will contain a list of all 
 the modules which have been updated, including their current version and the version they have been updated to.
+
+For projects that require CiviCRM, there's also a `CIVICRM_ROOT` variable that can be useful. The image ships with a 
+standard `civicrm.settings.php` file, which will be used while setting up the site for updates. The variable 
+specifies the root directory of CiviCRM. By default, it points to `sites/all/modules/civicrm`, but, if necessary, the 
+variable can be set to point to a different location.
 
 ## Notifying about updates
 
@@ -89,3 +94,16 @@ Slack:
 Note that in order to be able to access the output of a step, you need to give it an `id` (`security-updates` in this 
 case). Also note that `branch` will be empty in case no security updates were applied. We can use that inside an `if` 
 and avoid sending the notification in case nothing was updated.
+
+## Building and Pushing images
+
+There's a `build.sh` script that will automatically build and push all the variants available for the image. Here's an 
+example of how to build images for version 1.2.0:
+
+```shell script
+./build.sh 1.2.0
+```
+
+This will generate the following images:
+- compucorp/drupal7-security-updates-action:1.2.0-php7.2
+- compucorp/drupal7-security-updates-action:1.2.0-php5.6

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,6 @@
 # action.yml
 name: 'Drupal 7 Security Updates'
 description: 'Automatically apply security updates to a Drupal 7 site'
-inputs:
-  github_token:
-    description: 'Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
-    required: true
 outputs:
   branch:
     description: 'The branch to which the security updates have been pushed'
@@ -13,5 +9,3 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.github_token }}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ex
+
+[ -z "$1" ] && echo "Please pass the version number. Example: ./build.sh 1.0.1" && exit 1
+
+image_name=compucorp/drupal7-security-updates-action
+tag="$image_name:${1}"
+php5_variant="${tag}-php5.6"
+php7_variant="${tag}-php7.2"
+
+docker build --build-arg php_version=5.6 -t "$php5_variant" .
+docker build -t "$php7_variant" .
+docker push $image_name

--- a/civicrm.settings.php
+++ b/civicrm.settings.php
@@ -1,0 +1,49 @@
+<?php
+global $civicrm_root, $civicrm_setting, $civicrm_paths;
+
+
+$civicrm_root = getenv('GITHUB_WORKSPACE') . DIRECTORY_SEPARATOR . getenv('CIVICRM_ROOT');
+$templateDir = __DIR__.'/files/civicrm/templates_c';
+
+define('CIVICRM_UF', 'Drupal');
+define('CIVICRM_UF_DSN', 'mysql://root@mysql:3306/drupal?new_link=true');
+define('CIVICRM_DSN', 'mysql://root@mysql:3306/civicrm?new_link=true');
+define('CIVICRM_UF_BASEURL', 'http://example.org');
+define('CIVICRM_SITE_KEY', 'repowiqurewqiopruewqiopruewqiopurewqiopurewioqpurewq');
+define('CIVICRM_DB_CACHE_CLASS', 'ArrayCache');
+define('CIVICRM_LOGGING_DSN', CIVICRM_DSN);
+define('CIVICRM_TEMPLATE_COMPILEDIR', $templateDir);
+define('CIVICRM_DOMAIN_ID', 1);
+define('CIVICRM_CLEANURL', 1);
+define('CIVICRM_GETTEXT_NATIVE', 1);
+define('CIVICRM_MAIL_SMARTY', 0 );
+define('CIVICRM_DB_CACHE_HOST', 'localhost');
+define('CIVICRM_DB_CACHE_PORT', 11211);
+define('CIVICRM_DB_CACHE_PASSWORD', '' );
+define('CIVICRM_DB_CACHE_TIMEOUT', 3600 );
+define('CIVICRM_DB_CACHE_PREFIX', '');
+define('CIVICRM_DEADLOCK_RETRIES', 3);
+
+// this is a duplicate of CIVICRM_TEMPLATE_COMPILEDIR but required for the directory settings page
+$civicrm_setting['Directory Preferences']['customTemplateDir'] = $templateDir;
+
+// Directory/URL overrides
+$civicrm_setting['Directory Preferences']['uploadDir'] = '[civicrm.files]/upload';
+$civicrm_setting['Directory Preferences']['customFileUploadDir'] = '[civicrm.files]/custom/';
+$civicrm_setting['Directory Preferences']['imageUploadDir'] = '[civicrm.files]/persist/contribute/' ;
+$civicrm_setting['Directory Preferences']['customTemplateDir'] = '[cms.root]/sites/all/civicrm_custom/templates';
+$civicrm_setting['Directory Preferences']['customPHPPathDir'] = '[cms.root]/sites/all/civicrm_custom/php';
+$civicrm_setting['Directory Preferences']['extensionsDir'] = '[cms.root]/sites/all/civicrm_extensions';
+$civicrm_setting['URL Preferences']['userFrameworkResourceURL'] = '[civicrm.root]/';
+$civicrm_setting['URL Preferences']['imageUploadURL'] = '[civicrm.files]/persist/contribute/';
+$civicrm_setting['URL Preferences']['extensionsURL'] = $civicrm_setting['Directory Preferences']['extensionsDir'];
+
+
+$include_path = '.' . PATH_SEPARATOR . $civicrm_root . PATH_SEPARATOR . $civicrm_root . DIRECTORY_SEPARATOR . 'packages' . PATH_SEPARATOR . get_include_path( );
+if (set_include_path( $include_path ) === false) {
+    echo "Could not set the include path";
+    exit();
+}
+
+require_once 'CRM/Core/ClassLoader.php';
+CRM_Core_ClassLoader::singleton()->register();

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "require-dev": {
-        "squizlabs/php_codesniffer": "^3.5"
-    }
+  "require-dev": {
+    "squizlabs/php_codesniffer": "^3.5"
+  }
 }

--- a/create-pull-request.php
+++ b/create-pull-request.php
@@ -9,7 +9,11 @@ $token = getenv('GITHUB_TOKEN');
 $repository = getenv('GITHUB_REPOSITORY');
 $body = file_get_contents('php://stdin');
 
-['h' => $head] = getopt('h:');
+$opts = getopt('h:');
+
+if (empty($opts['h'])) {
+    throw new RuntimeException('Head branch not specified!');
+}
 
 if (empty($user)) {
     throw new RuntimeException('GITHUB_ACTOR not set!');
@@ -27,9 +31,7 @@ if (empty($body)) {
     throw new RuntimeException('Update message empty!');
 }
 
-if (empty($head)) {
-    throw new RuntimeException('Head branch not specified!');
-}
+$head = $opts['h'];
 
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, "https://api.github.com/repos/$repository/pulls");

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 
-# Copies a settings file with some predefined database configuration
-# which assumes this action will run in a workflow containing a
-# service named "mysql", running MySQL with a valid database for
-# the site we want to apply the security updates to. The database name
-# is assumed to be "drupal".
-cp /settings.php "$GITHUB_WORKSPACE/sites/default/settings.php"
-
 set -x
 
-# $1 is the github_token param passed to the action via
-[ -z "$1" ] && echo "Missing Github Token" && exit 1
+# Copies settings files with some predefined database configuration
+# which assumes this action will run in a workflow containing a
+# service named "mysql", running MySQL with valid databases for
+# the site we want to apply the security updates to. The database names
+# are assumed to be "drupal" and "civicrm".
+cp /{,civicrm.}settings.php "$GITHUB_WORKSPACE/sites/default/"
 
-export GITHUB_TOKEN=$1
+[ -z "$GITHUB_TOKEN" ] && echo "Missing Github Token" && exit 1
 
 git fetch origin --tags
 


### PR DESCRIPTION
## Overview
Some of our projects haven't been updated to be compatible with PHP 7.2 yet, so the action also needs to work with PHP 5.6.

## Technical Details

The main piece of work to make that happen was actually done in the `compucorp/civicrm-buildkit` image, which now offers php 5.6 variants.

With that done, we've introduced an `ARG` in the `Dockerfile` which allows to specify which variation of the image we want to use. The default is `7.2`, meaning that `compucorp/civicrm-buildkit` with php 7.2 will be used.

This change, however, forced us to also change how the image is build. Up until now, we were using as `uses: compucorp/drupal7-security-updates`. This would make Github Actions to clone the repo and build the image itself. Unfortunately, it's not possible to pass build params to this process, which means it would always build an PHP 7.2 image. To avoid this limitation, we will now start pushing images to docker hub. This way, to tell Github to download them from the registry instead of trying to build them itself.

This requires a few changes in how the action works though. Previously, we would pass the `GITHUB_TOKEN` as an input to the action. However, actions pulled from docker hub don't support that, so now we need to pass the token via an Environment variable.

Finally, since w'll need variations of the image, a build script (`build.sh`) was added to help with the process of building and pushing the images to Docker hub. Please check the `README` for more details.

## Comments
The `build-pull-request.php` script had to ve updated to be compatible with PHP 5.6 as well.

A sample `civicrm.settings.php` was added to ensure the action can be used on projects that also depend on civi, as during the tests it was found that drush will warning about this file being missed in civicrm project (it would not fail though).