### PR TITLE
IN-577: Avoid permission errors during the execution of the action

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,19 @@ else
     git checkout $security_updates_branch
 fi
 
+# The action is supposed to be run together with a mysql-anondb
+# container.
+# The db in this container might have these variables set to a
+# directory that is not available during the execution of the
+# script, so we force them to point to a location that:
+# 1) We're sure it exists
+# 2) We know we have write/read permissions
+#
+# Without this, we might run into permission issues while running
+# commands like drush cc or updb
+drush vset file_temporary_path /tmp
+drush vset file_private_path /tmp
+
 # Since we've switched to a new branch, let's first run basic updates
 # to ensure we'll be able to check for modules updates
 drush cc all


### PR DESCRIPTION
## Overview

The automated security update workflow was failing for some of our sites due to permission issues.

Here are some examples extracted from the logs:

```
2020-11-19T12:41:47.8485089Z + drush cc all
2020-11-19T12:41:48.7942547Z file_put_contents(/github/workspace/sites/default/files/civicrm/templates_c/CachedExtLoader.7860391564b8ca1dd77dc199bbce2c28.php):  [warning]
2020-11-19T12:41:48.7944077Z failed to open stream: No such file or directory ClassLoader.php:76
2020-11-19T12:42:02.8839544Z file_put_contents(temporary://fileBpG6Aw): failed to open stream:      [warning]
2020-11-19T12:42:02.8841596Z "DrupalTemporaryStreamWrapper::stream_open" call failed file.inc:1986
2020-11-19T12:42:09.0357737Z 'all' cache was cleared.                                               [success]
2020-11-19T12:42:09.0358504Z The file could not be created.                                           [error]
2020-11-19T12:42:09.0364346Z GMap is unable to save the marker bundle. Please check                   [error]
2020-11-19T12:42:09.0365066Z gmap_markers.js permissions!
```

```
2020-11-19T15:43:37.4095480Z + drush pm-updatecode --security-only -y
2020-11-19T15:43:39.6909143Z Update information last refreshed: Thu, 19/11/2020 - 15:43
2020-11-19T15:43:39.6910613Z  Name    Installed Version  Proposed version  Message                   
2020-11-19T15:43:39.6911622Z  Drupal  7.73               7.74              SECURITY UPDATE available 
2020-11-19T15:43:39.6912239Z 
2020-11-19T15:43:39.6912671Z 
2020-11-19T15:43:39.6913368Z Code updates will be made to drupal core.
2020-11-19T15:43:39.6915833Z WARNING:  Updating core will discard any modifications made to Drupal core files, most noteworthy among these are .htaccess and robots.txt.  If you have made any modifications to these files, please back them up before updating so that you can re-create your modifications in the updated version of the file.
2020-11-19T15:43:39.6919231Z Note: Updating core can potentially break your site. It is NOT recommended to update production sites without prior testing.
2020-11-19T15:43:39.6922437Z 
2020-11-19T15:43:39.6922944Z Do you really want to continue? (y/n): y
2020-11-19T15:43:40.7799745Z Project drupal was updated successfully. Installed version is now 7.74.
2020-11-19T15:43:40.7806056Z Backups were saved into the directory                                       [ok]
2020-11-19T15:43:40.7808139Z /github/home/drush-backups/drupal/20201119154337/drupal.
2020-11-19T15:43:45.0199066Z array_combine(): Both parameters should have an equal number of        [warning]
2020-11-19T15:43:45.0199976Z elements Relationship.php:2267
2020-11-19T15:43:45.5404328Z array_combine(): Both parameters should have an equal number of        [warning]
2020-11-19T15:43:45.5405797Z elements Relationship.php:2267
2020-11-19T15:43:45.8351628Z file_put_contents(temporary://fileMfiltv): failed to open stream:      [warning]
2020-11-19T15:43:45.8353103Z "DrupalTemporaryStreamWrapper::stream_open" call failed file.inc:2012
2020-11-19T15:43:46.4444574Z 'all' cache was cleared.                                               [success]
2020-11-19T15:43:46.4450998Z The file could not be created.                                           [error]
```

## Before

The reason for the error is that some of the anonymized dbs used for the automated security updates have the public and/or temporary files path configured to a location that doesn't exist or could not be read by the action.

## After

After importing the anonymized db, the action will override the location of public and temporary files and set them to `/tmp`, which we know to exist and we have the necessary permissions to write/read.
