### PR TITLE
IN-578: Add script for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+workdir

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ standard `civicrm.settings.php` file, which will be used while setting up the si
 specifies the root directory of CiviCRM. By default, it points to `sites/all/modules/civicrm`, but, if necessary, the 
 variable can be set to point to a different location.
 
+### Local testing
+
+This project assumes it will be executed as part of a Github Actions workflow. Because of that, it has some certain 
+requirements to be able to run and it assumes all of them will be met whenever it gets executed. Unfortunately, 
+this makes is really difficult to test it locally, as you would need to manually create docker containers, set 
+environment variables, and clone repositories.
+
+You can use the `test.sh` script to make this process a little bit easier. It will take care of:
+
+- Checking if the necessary environment variables are available
+- Clone the repository following an approach similar to what Github Actions does
+- Initialize a local mysql-anondb container
+- Run the drupal7-security-update container (which in fact will run the action itself)
+
+For more details on how to run the script, simply run `test.sh` without any params.
+
+Note that this was developed only for simple troubleshooting and doesn't fully replicate what Github Actions does. For 
+example, the script doesn't clean things up after it finishes. If you want to run it multiple times, you'll need to 
+manually remove the `mysql` container and cloned repositories inside `workdir`.
+
 ## Notifying about updates
 
 The action isn't responsible for any kind of notification itself, but it exposes 2 outputs (`branch` and `pull-request`), 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,9 @@ drush updb -y
 # a nice update message for the commit and Pull Request
 drush pm-updatestatus --security-only --format=csv | php /build-update-message.php > /update-message.txt
 
+# Exit if the update message is empty (i.e. no security updates available)
+[ ! -s /update-message.txt ] && exit 0
+
 # Do the actual update of modules
 drush pm-updatecode --security-only -y
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,7 +85,23 @@ git push "${remote_repo}" HEAD:$security_updates_branch
 echo "::set-output name=branch::$security_updates_branch"
 
 # Let people know how the branch was created and how to fix conflicts, if there are any
-[ $base_branch_or_tag != "master" ] && printf "\n\n*Important note*: This update was created from the %s tag. Conflicts are expected in case \`master\` is ahead the tag. If that is the case, the conflicts should be manually fixed in a new branch" $base_branch_or_tag >> /update-message.txt
+if [ $base_branch_or_tag != "master" ]
+then
+  (cat <<PRNOTE
+
+## Important notes
+
+This update was created from the \`$base_branch_or_tag\` tag. Conflicts are expected in case \`master\` is ahead the tag. If that is the case, the conflicts should be manually fixed in a new branch.
+
+Also, keep in mind that the diff displayed by github might not reflect the reality. This is due to [how Github does the comparisons](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons):
+
+> By default, pull requests on GitHub show a three-dot diff, or a comparison between the most recent version of the topic branch and the commit where the topic branch was last synced with the base branch.
+
+In other words, the comparison will show the differences between the security updates branch and master, as it was when the tag was created rather than **how it is today**. This might end up in Github saying the Pull Request can be merged successfully, while it actually has conflicts. To fix this, you'll need to rebase the security updates branch on top of \`master\`.
+PRNOTE
+) >> /update-message.txt
+
+fi
 
 pull_request_url=$(php /create-pull-request.php -h $security_updates_branch < /update-message.txt)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,17 @@ drush pm-updatestatus --security-only --format=csv | php /build-update-message.p
 
 # Do the actual update of modules
 drush pm-updatecode --security-only -y
+
+# Drupal core updates will revert any customizations made to the .gitignore
+# file, so we need to make sure of undoing that. It's safe to always run
+# this, as it will just exit silently if there are no changes
+# See: https://www.drupal.org/project/drupal/issues/1170538
+git checkout -- .gitignore
+
+# Let's remove the settings files created by this script so they won't get
+# committed by mistake in case they are not ignored by git
+rm -f "$GITHUB_WORKSPACE/sites/default/"{,civicrm.}settings.php
+
 git add .
 
 # Exit if there are no changes to be committed (i.e. no security updates)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -e
+
+function printUsage() {
+  echo "Usage: test.sh <repository> <username>"
+  echo "Example: test.sh compucorp/rse davialexandre"
+  echo "The script expects the following environment variables to be defined in order for it to run:"
+  echo "  GITHUB_TOKEN: a personal access token from the given user with permissions to clone and create pull requests to the given repository"
+  echo "  AWS_ACCESS_KEY: a access key with permission to read from the anonymized-db S3 bucket used by the mysql-anondb docker image"
+  echo "  AWS_SECRET_KEY: the secret key for the given AWS_ACCESS_KEY"
+}
+
+function getContainerStatus() {
+  docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" "$1"
+}
+
+[ -z "$1" ] && echo "Missing repository!" && printUsage && exit 1
+[ -z "$2" ] && echo "Missing username!" && printUsage && exit 1
+[ -z "$GITHUB_TOKEN" ] && echo "Missing GITHUB_TOKEN" && printUsage && exit 1
+[ -z "$AWS_ACCESS_KEY" ] && echo "Missing AWS_ACCESS_KEY" && printUsage && exit 1
+[ -z "$AWS_SECRET_KEY" ] && echo "Missing AWS_ACCESS_KEY" && printUsage && exit 1
+
+set -x
+
+repository=$1
+github_username=$2
+
+## Clone the repository following an approach similar to what https://github.com/actions/checkout does
+workdir="$PWD/workdir/$repository"
+mkdir -p "$workdir"
+cd "$workdir"
+git init
+git remote add origin "https://$github_username:$GITHUB_TOKEN@github.com/$repository"
+git -c protocol.version=2 fetch --prune --progress --no-recurse-submodules origin "+refs/heads/*:refs/remotes/origin/*" "+refs/tags/*:refs/tags/*"
+git checkout --progress --force -B master refs/remotes/origin/master
+
+# We need the FROM_SITE in order to start the mysql-anondb container
+from_site=$(grep -Eoh "FROM_SITE: (.+?)" "$workdir"/.github/workflows/* | cut -d ' ' -f 2)
+[ -z "$from_site" ] \
+  && echo "Couldn't extract the FROM SITE from the workflow file. Please check if this project has been configured for automated security updates" \
+  && exit 1
+
+# Some projects will need the PHP 5.6 of the action and some other will use 7.2
+# (or others in the future), so we extract that from the workflow instead of
+# hardcoding it on this script
+action_docker_image=$(grep -Eoh "compucorp/drupal7-security-updates-action:.+?" "$workdir"/.github/workflows/*)
+[ -z "$action_docker_image" ] \
+  && echo "Couldn't find the docker image to run the security updates. Please check if this project has been configured for automated security updates" \
+  && exit 1
+
+# The action has a default value for the CIVICRM_ROOT variable, but this can be overridden in some projects
+# The logic is to use the default value in the image, otherwise we use the custom one in the workflow
+default_civicrm_root=$(docker inspect --format="{{range .Config.Env}}{{println .}}{{end}}" "$action_docker_image" | grep CIVICRM_ROOT | cut -d '=' -f 2)
+action_civicrm_root=$(grep -Eoh "CIVICRM_ROOT: (.+?)" "$workdir"/.github/workflows/* | cut -d ' ' -f 2)
+civicrm_root=${action_civicrm_root:-"$default_civicrm_root"}
+
+run_id=$(echo "$repository" | tr "/" "_")_$(date +%Y%m%d%H%I%S)
+
+# We'll be creating 2 containers. One for the database and one for the
+# security update action. In order for them to be able to talk to each
+# other, both need to be attached to the same network.
+docker network create "$run_id"
+docker run -d \
+  --network "$run_id" \
+  --name mysql \
+  -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
+  -e FROM_SITE="$from_site" \
+  -e S3_ACCESS_KEY="$AWS_ACCESS_KEY" \
+  -e S3_SECRET_KEY="$AWS_SECRET_KEY" \
+  -e ANONDB_S3_BUCKET=anonymized-dbs \
+  compucorp/mysql-anondb
+
+#Disable command tracing, to avoid printing the getContainerStatus in every cycle of the loop
+set +x
+echo "Waiting for the mysql container to become ready"
+while [ "$(getContainerStatus "mysql")" = "starting" ];
+do
+  echo -n "."
+  sleep 5
+done
+
+set -x
+
+if [ "$(getContainerStatus "mysql")" = 'healthy' ];
+then
+  github_workspace="/github/workspace"
+  docker run \
+  --rm \
+  --network "$run_id" \
+  --workdir "$github_workspace" \
+  -e GITHUB_TOKEN \
+  -e GITHUB_WORKSPACE="$github_workspace" \
+  -e GITHUB_ACTOR="$github_username" \
+  -e GITHUB_REPOSITORY="$repository" \
+  -e CIVICRM_ROOT="$civicrm_root" \
+  -v "$workdir":"$github_workspace" \
+  "$action_docker_image"
+fi


### PR DESCRIPTION
## Problem

Since this was designed as a github action, it assumes some environment variables and other requirements will be in place in order for it to run. Setting all this manually is a time-consuming and makes local troubleshooting difficult.

## Solution

Added the `test.sh` script which does most of the heavy lifting and tries to replicate part of what Github Actions does when running the action as part of a workflow. Please check the README for more details on how it works.