### PR TITLE
IN-485: Ignore .gitignore changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,9 @@ drush updb -y
 # a nice update message for the commit and Pull Request
 drush pm-updatestatus --security-only --format=csv | php /build-update-message.php > /update-message.txt
 
+# Exit if the update message is empty (i.e. no security updates available)
+[ ! -s /update-message.txt ] && exit 0
+
 # Do the actual update of modules
 drush pm-updatecode --security-only -y
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,7 +85,23 @@ git push "${remote_repo}" HEAD:$security_updates_branch
 echo "::set-output name=branch::$security_updates_branch"
 
 # Let people know how the branch was created and how to fix conflicts, if there are any
-[ $base_branch_or_tag != "master" ] && printf "\n\n*Important note*: This update was created from the %s tag. Conflicts are expected in case \`master\` is ahead the tag. If that is the case, the conflicts should be manually fixed in a new branch" $base_branch_or_tag >> /update-message.txt
+if [ $base_branch_or_tag != "master" ]
+then
+  (cat <<PRNOTE
+
+## Important notes
+
+This update was created from the \`$base_branch_or_tag\` tag. Conflicts are expected in case \`master\` is ahead the tag. If that is the case, the conflicts should be manually fixed in a new branch.
+
+Also, keep in mind that the diff displayed by github might not reflect the reality. This is due to [how Github does the comparisons](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons):
+
+> By default, pull requests on GitHub show a three-dot diff, or a comparison between the most recent version of the topic branch and the commit where the topic branch was last synced with the base branch.
+
+In other words, the comparison will show the differences between the security updates branch and master, as it was when the tag was created rather than **how it is today**. This might end up in Github saying the Pull Request can be merged successfully, while it actually has conflicts. To fix this, you'll need to rebase the security updates branch on top of \`master\`.
+PRNOTE
+) >> /update-message.txt
+
+fi
 
 pull_request_url=$(php /create-pull-request.php -h $security_updates_branch < /update-message.txt)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,17 @@ drush pm-updatestatus --security-only --format=csv | php /build-update-message.p
 
 # Do the actual update of modules
 drush pm-updatecode --security-only -y
+
+# Drupal core updates will revert any customizations made to the .gitignore
+# file, so we need to make sure of undoing that. It's safe to always run
+# this, as it will just exit silently if there are no changes
+# See: https://www.drupal.org/project/drupal/issues/1170538
+git checkout -- .gitignore
+
+# Let's remove the settings files created by this script so they won't get
+# committed by mistake in case they are not ignored by git
+rm -f "$GITHUB_WORKSPACE/sites/default/"{,civicrm.}settings.php
+
 git add .
 
 # Exit if there are no changes to be committed (i.e. no security updates)


### PR DESCRIPTION
## Problem

When updating Drupal core, the `.gitignore` file in the root folder might end-up being updated as well. That's because Drupal core packages are shipped with a default `.gitignore` file. As a result, this will overwrite any project specific customizations that we might have end-up adding to the file.

## Solution

To avoid that, the script will now check if the security updated changed the `.gitignore` file and will revert the changes in case there are any.

The script will also now remove the `settings.php` and `civicrm.settings.php` file it adds. This was done to avoid the files being committed to the security updates branch in case the `.gitignore` file inside the repo is not set to ignore them.

## Comments
This PR also includes two small updates that wouldn't justify a separate ticket and PR:

- More details about why conflicts might happen for Security Updates and possible ways to deal with them
- A small "performance" improvement in case there are no security updates available
